### PR TITLE
Fix usage example for gctf.centralized_gradients_for_optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Create a centralized gradients functions for a specified optimizer.
 
 ```py
 >>> opt = tf.keras.optimizers.Adam(learning_rate=0.1)
->>> optimizer.get_gradients = gctf.centralized_gradients_for_optimizer(opt)
+>>> opt.get_gradients = gctf.centralized_gradients_for_optimizer(opt)
 >>> model.compile(optimizer = opt, ...)
 ```
     


### PR DESCRIPTION
Fix usage examples in the docstrings as weel as the docs for `gctf.centralized_gradients_for_optimizer`

---

Closes #13 