### PR TITLE
Replace 'keras' with 'tensorflow.keras' in import

### DIFF
--- a/gctf/centralized_gradients.py
+++ b/gctf/centralized_gradients.py
@@ -1,5 +1,5 @@
 import tensorflow as tf
-import keras.backend as K
+import tensorflow.keras.backend as K
 
 
 def get_centralized_gradients(optimizer, loss, params):


### PR DESCRIPTION
In newer version of TF `import keras` will raise an error. I updated the import statement to `import tensorflow.keras`.